### PR TITLE
Add basic music player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/components/music-player.js
+++ b/components/music-player.js
@@ -1,0 +1,63 @@
+import { useState, useRef, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export const MusicPlayer = ({ tracks }) => {
+  const [currentTrack, setCurrentTrack] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const audioRef = useRef(null);
+
+  const togglePlayPause = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+    } else {
+      audio.play();
+      setIsPlaying(true);
+    }
+  };
+
+  const handleNext = () => {
+    setCurrentTrack((prev) => (prev + 1) % tracks.length);
+  };
+
+  const handlePrev = () => {
+    setCurrentTrack((prev) => (prev - 1 + tracks.length) % tracks.length);
+  };
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const onEnded = () => {
+      handleNext();
+    };
+    audio.addEventListener("ended", onEnded);
+    return () => {
+      audio.removeEventListener("ended", onEnded);
+    };
+  }, [tracks.length]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.load();
+    if (isPlaying) {
+      audio.play();
+    }
+  }, [currentTrack]);
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex items-center gap-2">
+        <Button onClick={handlePrev}>Prev</Button>
+        <Button onClick={togglePlayPause}>{isPlaying ? "Pause" : "Play"}</Button>
+        <Button onClick={handleNext}>Next</Button>
+      </div>
+      <p className="font-bold">{tracks[currentTrack].title}</p>
+      <audio ref={audioRef} src={tracks[currentTrack].src} />
+    </div>
+  );
+};
+

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -99,7 +99,13 @@ export default function PokemonPackOpener() {
             <motion.div
               key={currentCard}
               onClick={handleNextCard}
-              className={\`absolute top-0 left-0 w-full h-full rounded-2xl overflow-hidden shadow-2xl cursor-pointer \${cards[currentCard].rarity === "ultra" ? "ring-4 ring-purple-500 animate-pulse" : cards[currentCard].rarity === "rare" ? "ring-2 ring-yellow-400" : ""}\`}
+              className={`absolute top-0 left-0 w-full h-full rounded-2xl overflow-hidden shadow-2xl cursor-pointer ${
+                cards[currentCard].rarity === "ultra"
+                  ? "ring-4 ring-purple-500 animate-pulse"
+                  : cards[currentCard].rarity === "rare"
+                  ? "ring-2 ring-yellow-400"
+                  : ""
+              }`}
               initial={{ x: 0, opacity: 1 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: 500, opacity: 0 }}

--- a/pages/music.js
+++ b/pages/music.js
@@ -1,0 +1,18 @@
+import { MusicPlayer } from "@/components/music-player";
+
+export default function MusicPage() {
+  const tracks = [
+    { title: "Pack Rip", src: "/sounds/rip.mp3" },
+    {
+      title: "SoundHelix Sample",
+      src: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+    },
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-gray-100">
+      <h1 className="text-2xl font-bold mb-4">Music Player</h1>
+      <MusicPlayer tracks={tracks} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `MusicPlayer` component with play/pause and track navigation
- provide `/music` page demonstrating the player
- configure path aliases and ignore build artifacts

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a788825d2083279d7f287fc3ca1220